### PR TITLE
Improve usage of post image

### DIFF
--- a/src/app/blog/blog.module.ts
+++ b/src/app/blog/blog.module.ts
@@ -19,6 +19,7 @@ import { BlogRoutingModule } from './blog-routing.module';
 import { CoreModule } from 'app/core';
 import { EditorModule } from 'app/editor';
 import { SocialModule } from 'app/social';
+import { WidgetsModule } from 'app/widgets';
 import { BlogComponent } from './blog.component';
 import { PostListComponent } from './post-list/post-list.component';
 import { HomeComponent } from './home/home.component';
@@ -52,6 +53,7 @@ import { TagPostListComponent } from './tag-post-list/tag-post-list.component';
     CoreModule,
     EditorModule,
     SocialModule,
+    WidgetsModule,
     BlogRoutingModule,
   ],
   declarations: [

--- a/src/app/blog/core/post.model.ts
+++ b/src/app/blog/core/post.model.ts
@@ -15,6 +15,7 @@ export class PostSchema extends PostMinimalSchema {
   published?: Date;
   isDraft: boolean;
   imageUrl?: string;
+  imageCaption?: string;
   previous?: PostMinimalSchema;
   next?: PostMinimalSchema;
 }
@@ -45,6 +46,7 @@ export class PostAdapter implements IAdapter<Post> {
       content: data.content,
       tags: data.tags,
       imageUrl: data.image_url,
+      imageCaption: data.image_caption,
       created: new Date(data.created),
       published: data.published ? new Date(data.published) : null,
       isDraft: data.is_draft,

--- a/src/app/blog/core/post.payload.ts
+++ b/src/app/blog/core/post.payload.ts
@@ -4,5 +4,6 @@ export interface PostPayload {
   slug: string;
   description: string;
   image_url: string;
+  image_caption: string;
   tags: string[];
 }

--- a/src/app/blog/post-detail/post-detail.component.html
+++ b/src/app/blog/post-detail/post-detail.component.html
@@ -25,6 +25,8 @@
     </p>
   </header>
 
+  <app-image *ngIf="post.imageUrl" [src]="post.imageUrl" [caption]="post.imageCaption"></app-image>
+
   <markdown [data]="post.content"></markdown>
 
   <app-post-footer></app-post-footer>

--- a/src/app/blog/post-editor/post-editor.component.html
+++ b/src/app/blog/post-editor/post-editor.component.html
@@ -16,12 +16,17 @@
 
       <mat-form-field id="description-field" class="full-width">
         <input matInput type="text" formControlName="description" placeholder="Description" (change)="makeDirty()">
-        <mat-hint>Should be set for social cards and RSS support.</mat-hint>
+        <mat-hint>Also used in social cards and RSS.</mat-hint>
       </mat-form-field>
 
       <mat-form-field id="image-url-field" class="full-width">
         <input matInput type="url" formControlName="image_url" placeholder="Image URL" (change)="makeDirty()">
-        <mat-hint>Should be set for social cards and RSS support.</mat-hint>
+        <mat-hint>Also used in social cards and RSS.</mat-hint>
+      </mat-form-field>
+
+      <mat-form-field id="image-caption-field" class="full-width">
+        <input matInput type="text" formControlName="image_caption" placeholder="Image caption" (change)="makeDirty()">
+        <mat-hint>Displayed under the image, if set.</mat-hint>
       </mat-form-field>
 
       <app-tags-field [control]="tagsControl" (change)="makeDirty()"></app-tags-field>
@@ -49,7 +54,7 @@
     </div>
   </span>
 
-  <app-editor [control]="contentControl" [mdContent]="content" (dirty)="makeDirty()">
+  <app-editor [control]="contentControl" [mdContent]="content" (dirty)="makeDirty()" [imageUrl]="imageUrl" [imageCaption]="imageCaption">
     <button app-editor-tool mat-raised-button color="primary" [disabled]="!formGroup.valid">
       Save <ng-template [ngIf]="!post || (post && post.isDraft)">draft</ng-template>
     </button>

--- a/src/app/blog/post-editor/post-editor.component.scss
+++ b/src/app/blog/post-editor/post-editor.component.scss
@@ -13,7 +13,7 @@
     display: grid;
     grid-column-gap: 2em;
     grid-template-columns: 1fr 1fr;
-    grid-template-areas: "title slug" "description description" "image-url .";
+    grid-template-areas: "title slug" "description description" "image-url image-description";
   }
 }
 
@@ -31,4 +31,8 @@
 
 #image-url-field {
   grid-area: image-url;
+}
+
+#image-description-field {
+  grid-area: image-description;
 }

--- a/src/app/editor/editor/editor.component.html
+++ b/src/app/editor/editor/editor.component.html
@@ -19,5 +19,11 @@
       #autosize="cdkTextareaAutosize"
       cdkAutosizeMinRows="30"></textarea>
   </mat-form-field>
-  <markdown id="preview" *ngIf="previewActive" [data]="mdContent"></markdown>
+  <section id="preview">
+    <div *ngIf="imageUrl" class="markdown-image" id="image">
+      <img [src]="imageUrl" alt="">
+      <figcaption *ngIf="imageCaption">{{ imageCaption }}</figcaption>
+    </div>
+    <markdown *ngIf="previewActive" [data]="mdContent"></markdown>
+  </section>
 </div>

--- a/src/app/editor/editor/editor.component.html
+++ b/src/app/editor/editor/editor.component.html
@@ -20,10 +20,7 @@
       cdkAutosizeMinRows="30"></textarea>
   </mat-form-field>
   <section id="preview">
-    <div *ngIf="imageUrl" class="markdown-image" id="image">
-      <img [src]="imageUrl" alt="">
-      <figcaption *ngIf="imageCaption">{{ imageCaption }}</figcaption>
-    </div>
+    <app-image *ngIf="imageUrl" [src]="imageUrl" [caption]="imageCaption" id="image"></app-image>
     <markdown *ngIf="previewActive" [data]="mdContent"></markdown>
   </section>
 </div>

--- a/src/app/editor/editor/editor.component.scss
+++ b/src/app/editor/editor/editor.component.scss
@@ -53,3 +53,10 @@
     }
   }
 }
+
+#image {
+  img {
+    max-width: 100%;
+    height: auto;
+  }
+}

--- a/src/app/editor/editor/editor.component.ts
+++ b/src/app/editor/editor/editor.component.ts
@@ -21,6 +21,8 @@ interface EditorChange {
 export class EditorComponent {
 
   @Input() mdContent: string;
+  @Input() imageUrl: string;
+  @Input() imageCaption: string;
   @Input() control: FormControl;
   @ViewChild('autosize') autoSize: MatTextareaAutosize;
   @Output() dirty: EventEmitter<void> = new EventEmitter();

--- a/src/app/widgets/image/image.component.html
+++ b/src/app/widgets/image/image.component.html
@@ -1,0 +1,4 @@
+<div class="markdown-image">
+  <img [src]="src" [alt]="caption">
+  <figcaption *ngIf="caption">{{ caption }}</figcaption>
+</div>

--- a/src/app/widgets/image/image.component.ts
+++ b/src/app/widgets/image/image.component.ts
@@ -1,0 +1,13 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-image',
+  templateUrl: './image.component.html',
+  styleUrls: ['./image.component.scss']
+})
+export class ImageComponent {
+
+  @Input() src: string;
+  @Input() caption = '';
+
+}

--- a/src/app/widgets/widgets.module.ts
+++ b/src/app/widgets/widgets.module.ts
@@ -7,6 +7,7 @@ import { TabsComponent } from './tabs/tabs.component';
 import { TabLinkDirective } from './tabs/tab-link.directive';
 import { PatchworkComponent } from './patchwork/patchwork.component';
 import { SpinnerComponent } from './spinner/spinner.component';
+import { ImageComponent } from './image/image.component';
 
 @NgModule({
   imports: [
@@ -18,12 +19,14 @@ import { SpinnerComponent } from './spinner/spinner.component';
     TabLinkDirective,
     PatchworkComponent,
     SpinnerComponent,
+    ImageComponent,
   ],
   exports: [
     TabsComponent,
     TabLinkDirective,
     PatchworkComponent,
     SpinnerComponent,
+    ImageComponent,
   ],
 })
 export class WidgetsModule { }


### PR DESCRIPTION
# Description

- Add an image caption field to the post editor

![screen shot 2018-09-23 at 23 50 09](https://user-images.githubusercontent.com/15911462/45933380-bdc58d00-bf8b-11e8-8979-a36c8f736da8.png)

- Render the image and its caption in the post editor preview

![screen shot 2018-09-23 at 23 51 09](https://user-images.githubusercontent.com/15911462/45933382-c1591400-bf8b-11e8-9401-ed8b928f1bff.png)

- Render the image and its caption in the post detail page

![screen shot 2018-09-23 at 23 51 51](https://user-images.githubusercontent.com/15911462/45933383-c4ec9b00-bf8b-11e8-9657-e8e8f2672a83.png)

- Plus some minor refactoring.