### PR TITLE
Update API key scheme

### DIFF
--- a/scripts/set-env.js
+++ b/scripts/set-env.js
@@ -14,7 +14,8 @@ export const environment = {
   adminSiteUrl: "${process.env.BACKEND_URL}/admin",
   backendUrl: "${process.env.BACKEND_URL}",
   apiUrl: "${process.env.BACKEND_URL}/api",
-  apiKey: "${process.env.API_KEY}",
+  apiToken: "${process.env.API_TOKEN}",
+  apiSecretKey: "${process.env.API_SECRET_KEY}",
 };
 `
 

--- a/src/app/core/auth/key.interceptor.ts
+++ b/src/app/core/auth/key.interceptor.ts
@@ -8,13 +8,14 @@ import { environment } from 'environments/environment';
 export class KeyInterceptor implements HttpInterceptor {
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    request = this.attachKey(request);
+    request = this.attachApiKey(request);
     return next.handle(request);
   }
 
-  private attachKey(request): HttpRequest<any> {
-    const key: string = environment.apiKey;
-    const headers = request.headers.set('Api-Key', key);
+  private attachApiKey(request: HttpRequest<any>): HttpRequest<any> {
+    const token: string = environment.apiToken;
+    const secretKey: string = environment.apiSecretKey;
+    const headers = request.headers.set('Api-Token', token).set('Api-Secret-Key', secretKey);
     return request.clone({ headers });
   }
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -6,7 +6,8 @@
 // `ng serve --env=dev`
 export const environment = {
   production: false,
-  apiKey: '',
+  apiToken: '',
+  apiSecretKey: '',
   backendUrl: '',
   adminSiteUrl: '',
   apiUrl: '',


### PR DESCRIPTION
# Description

Update the headers sent by `KeyInterceptor` to `Api-Token` and `Api-Secret-Key`.

# Deployment notes

The `API_KEY` environment variable will need to be replaced with `API_TOKEN` and `API_SECRET_KEY` (obtained from the backend API) in the CaptainDuckDuck admin.