### PR TITLE
Scroll to top when selecting post from list

### DIFF
--- a/src/app/blog/post-list/post-list.component.html
+++ b/src/app/blog/post-list/post-list.component.html
@@ -7,7 +7,7 @@
     <app-tag-list id="tags" [ngClass]="{'separated': post.published}" [tags]="post.tags" *ngIf="post.tags.length > 0"></app-tag-list>
 
     <h4>
-      <a [routerLink]="action === 'edit' ? ['/', post.slug, 'edit'] : ['/', post.slug]">
+      <a [routerLink]="getLink(post)" (click)="scrollTop()">
         {{ post.title }}
       </a>
     </h4>

--- a/src/app/blog/post-list/post-list.component.ts
+++ b/src/app/blog/post-list/post-list.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { Post } from '../core';
+import { ScrollService } from 'app/core';
 
 @Component({
   selector: 'app-post-list',
@@ -11,5 +12,19 @@ export class PostListComponent {
   @Input() posts: Post[] = [];
   @Input() action = '';
   @Input() ifEmpty = 'No blog posts here yet. Stay tuned!';
+
+  constructor(private scroll: ScrollService) { }
+
+  scrollTop() {
+    this.scroll.toTop();
+  }
+
+  getLink(post: Post): string[] {
+    if (this.action === 'edit') {
+      return ['/', post.slug, 'edit'];
+    } else {
+      return ['/', post.slug];
+    }
+  }
 
 }

--- a/src/app/blog/post-nav/post-nav.component.ts
+++ b/src/app/blog/post-nav/post-nav.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input } from '@angular/core';
 import { Post } from '../core';
-import jump from 'jump.js';
+import { ScrollService } from 'app/core';
 
 
 @Component({
@@ -13,6 +13,8 @@ export class PostNavComponent {
   @Input() relative: Post;
   @Input() type: string;
 
+  constructor(private scroll: ScrollService) { }
+
   get label(): string {
     return this.type === 'previous' ? 'Prev' : 'Next';
   }
@@ -22,7 +24,7 @@ export class PostNavComponent {
   }
 
   scrollTop() {
-    jump('#top', { duration: 500 })
+    this.scroll.toTop();
   }
 
 }

--- a/src/app/core/scroll.service.ts
+++ b/src/app/core/scroll.service.ts
@@ -7,7 +7,7 @@ import jump from 'jump.js';
 })
 export class ScrollService {
 
-  toTop(duration: number = 500) {
-    jump('#top', { duration });
+  toTop(opts = {duration: 500}) {
+    jump('#top', opts);
   }
 }


### PR DESCRIPTION
# Description

Clicking on a post in the home page now scrolls to the top of the page so the reader can start reading right away.

Also some minor refactoring.