### PR TITLE
Disable login button and add spinner while authenticating

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -27,6 +27,7 @@ import { KeyInterceptor, TokenInterceptor } from './core';
 import { AppUpdatesModule } from './app-updates';
 import { ErrorInterceptor, ErrorsModule } from './errors';
 import { CookieConsentModule } from './cookie-consent';
+import { WidgetsModule } from './widgets';
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { NavbarComponent } from './navbar/navbar.component';
@@ -76,6 +77,7 @@ import { environment } from '../environments/environment';
     ErrorsModule,
     CookieConsentModule,
     AppUpdatesModule,
+    WidgetsModule,
     // Angular Material
     MatFormFieldModule,
     MatInputModule,

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -10,8 +10,9 @@
     <mat-form-field>
       <input type="password" matInput required [formControl]="password" placeholder="Password">
     </mat-form-field>
-    <button mat-raised-button color="primary" [disabled]="!formValid">
+    <button mat-raised-button color="primary" [disabled]="loading || !formValid">
       Log in
+      <fa-icon [icon]="faSpinner" spin="true" *ngIf="loading"></fa-icon>
     </button>
     <p class="text-warn pad-v-sm text-center" *ngIf="failed">
       Could not log in with the credentials provided.

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormControl } from '@angular/forms';
 import { Router } from '@angular/router';
 import { AuthService } from 'app/core';
+import { faSpinner } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
   selector: 'app-login',
@@ -13,6 +14,9 @@ export class LoginComponent implements OnInit {
   username: FormControl;
   password: FormControl;
 
+  faSpinner = faSpinner;
+
+  loading = false;
   failed: boolean;
 
   constructor(
@@ -31,9 +35,15 @@ export class LoginComponent implements OnInit {
 
   submit() {
     this.failed = false;
+    this.loading = true;
     this.auth.login(this.username.value, this.password.value).subscribe(
-      () => this.router.navigate([this.auth.redirectUrl || '/']),
-      (e) => this.failed = true,
+      () => {
+        this.router.navigate([this.auth.redirectUrl || '/']);
+      },
+      (e) => {
+        this.failed = true;
+        this.loading = false;
+      },
     );
   }
 


### PR DESCRIPTION
# Description

Although only used by administrators, the login button on login page was not disabled while an authentication request was in progress. This meant user could send multiple requests, which could lead to unexpected behavior.

Disable the button and add a progress spinner instead.

![screen shot 2018-10-06 at 12 34 35](https://user-images.githubusercontent.com/15911462/46570444-892adb80-c964-11e8-834f-8b7153eba34e.png)
