### PR TITLE
Fix bug on server-rendered paginated post resolvers

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -47,11 +47,10 @@ export class AppComponent implements OnInit, OnDestroy {
       tap((e) => this.navigating = e instanceof NavigationStart),
     ).subscribe());
 
+    // Configure Cookie Consent
     if (!this.cookieConsent.hasAnswered()) {
       this.cookieConsentPopup.createFor(this.viewContainerRef);
     }
-
-    // Configure Cookie Consent
     if (this.cookieConsent.hasConsented()) {
       this.analytics.activate();
     }

--- a/src/app/blog/blog-routing.module.ts
+++ b/src/app/blog/blog-routing.module.ts
@@ -18,7 +18,7 @@ const routes: Routes = [
         path: '',
         component: HomeComponent,
         resolve: { paginator: PostListResolver },
-        data: { pageId: 'home', title: '' },
+        data: { pageId: 'home' },
       },
       {
         path: 't/:tag',
@@ -30,7 +30,7 @@ const routes: Routes = [
         path: ':pk',
         component: PostDetailComponent,
         resolve: { post: PostDetailResolver },
-        data: { pageId: 'postDetail' },
+        data: { pageId: 'post-detail' },
       },
     ],
   },

--- a/src/app/blogging-core/paginator.ts
+++ b/src/app/blogging-core/paginator.ts
@@ -5,11 +5,7 @@ import * as qs from 'querystring';
 export class CursorPaginator<T> {
 
   // NOTE: next is a fully qualified URL
-  constructor(public next: string, private _results: T[]) { }
-
-  get results(): T[] {
-    return this._results;
-  }
+  constructor(public next: string, public results: T[]) { }
 
   static empty<T>(): CursorPaginator<T> {
     return new CursorPaginator<T>(null, []);

--- a/src/app/cookie-consent/cookie-consent.service.ts
+++ b/src/app/cookie-consent/cookie-consent.service.ts
@@ -35,7 +35,9 @@ export class CookieConsentService {
         return null;
       }
     }
-    return null;
+    // Cookie consent should not be shown on server-rendered page.
+    // Say user has denied by default.
+    return 'deny';
   }
 
   private set status(status: Status) {
@@ -65,7 +67,7 @@ export class CookieConsentService {
   }
 
   hasConsented(): boolean {
-    return this.status === 'allow'
+    return this.status === 'allow';
   }
 
   onAllow(): Observable<any> {


### PR DESCRIPTION
# Description

The implementation of pagination led to unexpected issues in the server-rendering of the app (issue with the TransferState API).

Reason why: service inheritance is not great in Angular. Use composition over inheritance.

Also some minor fixes to the cookie consent display logic.