### PR TITLE
Ensure API calls are made over HTTPS in production

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -23,7 +23,7 @@ import { Angulartics2Module } from 'angulartics2';
 import { Angulartics2GoogleAnalytics } from 'angulartics2/ga';
 
 import { markedOptionsFactory } from './markdown/options';
-import { KeyInterceptor, TokenInterceptor } from './core';
+import { KeyInterceptor, TokenInterceptor, HttpsInterceptor } from './core';
 import { AppUpdatesModule } from './app-updates';
 import { ErrorInterceptor, ErrorsModule } from './errors';
 import { CookieConsentModule } from './cookie-consent';
@@ -85,12 +85,14 @@ import { environment } from '../environments/environment';
     MatIconModule,
     MatMenuModule,
     MatProgressBarModule,
+    // Service worker
     ServiceWorkerModule.register('/ngsw-worker.js', { enabled: environment.production }),
   ],
   providers: [
     { provide: HTTP_INTERCEPTORS, useClass: KeyInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: TokenInterceptor, multi: true },
     { provide: HTTP_INTERCEPTORS, useClass: ErrorInterceptor, multi: true },
+    { provide: HTTP_INTERCEPTORS, useClass: HttpsInterceptor, multi: true },
     { provide: ErrorStateMatcher, useClass: ShowOnDirtyErrorStateMatcher }
   ],
   bootstrap: [AppComponent]

--- a/src/app/core/https.interceptor.ts
+++ b/src/app/core/https.interceptor.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
+import { environment } from 'environments/environment';
+
+
+@Injectable({
+  providedIn: 'root',
+})
+export class HttpsInterceptor implements HttpInterceptor {
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    return next.handle(this.ensureHttpsInProduction(req));
+  }
+
+  private ensureHttpsInProduction(req: HttpRequest<any>) {
+    if (environment.production) {
+      return req.clone({
+        url: req.url.replace('http://', 'https://'),
+      });
+    }
+    return req;
+  }
+}

--- a/src/app/core/index.ts
+++ b/src/app/core/index.ts
@@ -10,3 +10,4 @@ export * from './description.service';
 export * from './staticfiles.service';
 export * from './url.service';
 export * from './analytics.service';
+export * from './https.interceptor';


### PR DESCRIPTION
# Description

URLs automatically returned by Django (i.e. in cursor pagination) may use the HTTP scheme instead of HTTPS, which caused issues in production.