### PR TITLE
Remove dependency on Moment.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7234,14 +7234,6 @@
         "tslib": "^1.9.0"
       }
     },
-    "ngx-moment": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/ngx-moment/-/ngx-moment-3.1.0.tgz",
-      "integrity": "sha512-liX6iTfOY0XyI3rUuWNgGpgxoeD+DFaAl7UJ/ejl9Ama5cXzw8L1Eft6UQLUo1d80kjNMc6AL+L19CPMvUQ/BA==",
-      "requires": {
-        "tslib": "^1.9.0"
-      }
-    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "moment": "^2.22.2",
     "morgan": "^1.9.0",
     "ngx-markdown": "^6.1.0",
-    "ngx-moment": "^3.1.0",
     "reflect-metadata": "^0.1.12",
     "request": "^2.88.0",
     "rxjs": "^6.3.3",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,7 +7,6 @@ import { RouterModule } from '@angular/router';
 import { ServiceWorkerModule } from '@angular/service-worker';
 
 import { MarkdownModule, MarkedOptions } from 'ngx-markdown';
-import { MomentModule } from 'ngx-moment';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome'
 import { OverlayContainer } from '@angular/cdk/overlay';
 import {
@@ -58,7 +57,6 @@ import { environment } from '../environments/environment';
     ReactiveFormsModule,
     HttpClientModule,
     BrowserAnimationsModule,  // required for Angular animations
-    MomentModule,
     FontAwesomeModule,
     Angulartics2Module.forRoot([Angulartics2GoogleAnalytics], {
       // Deactivate page tracking initially/by default

--- a/src/app/blog/blog.module.ts
+++ b/src/app/blog/blog.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
-import { MomentModule } from 'ngx-moment';
 import { MarkdownModule } from 'ngx-markdown';
 
 import {
@@ -34,7 +33,6 @@ import { SearchComponent } from './search/search.component';
     CommonModule,
     FormsModule,
     ReactiveFormsModule,
-    MomentModule,
     MarkdownModule.forChild(),
     // Angular Material
     MatButtonModule,

--- a/src/app/blog/post-detail/post-detail.component.html
+++ b/src/app/blog/post-detail/post-detail.component.html
@@ -4,10 +4,10 @@
     <div id="meta">
       <div>
         <label class="text-muted" *ngIf="post.published">
-          {{ post.published | amDateFormat: 'LL' }}
+          {{ post.published | date:'longDate' }}
         </label>
         <label class="text-muted" *ngIf="!post.published">
-          Drafted {{ post.created | amDateFormat: 'LL' }}
+          Drafted {{ post.created | date:'longDate' }}
         </label>
         <app-tag-list id="tags" [tags]="post.tags" *ngIf="post.tags.length > 0"></app-tag-list>
       </div>

--- a/src/app/blogging-shared/blogging-shared.module.ts
+++ b/src/app/blogging-shared/blogging-shared.module.ts
@@ -2,7 +2,6 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 
-import { MomentModule } from 'ngx-moment';
 import {
   MatButtonModule,
 } from '@angular/material';
@@ -15,7 +14,6 @@ import { PostListComponent } from './post-list/post-list.component';
   imports: [
     CommonModule,
     RouterModule,
-    MomentModule,
     MatButtonModule,
   ],
   declarations: [

--- a/src/app/blogging-shared/post-list/post-list.component.html
+++ b/src/app/blogging-shared/post-list/post-list.component.html
@@ -2,7 +2,7 @@
   <li class="post" *ngFor="let post of posts">
     <div class="post-header">
       <label class="text-muted" *ngIf="post.published">
-        {{ post.published | amDateFormat: 'LL' }}
+        {{ post.published | date:'longDate' }}
       </label>
       <app-tag-list id="tag-list" [ngClass]="{'separated': post.published}" [tags]="post.tags" *ngIf="post.tags.length > 0"></app-tag-list>
     </div>

--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -30,7 +30,7 @@
   </ul>
 
   <p class="pad-h-sm">
-    © {{ now | amDateFormat: 'YYYY' }}
+    © {{ now | date:'y' }}
     &middot;
     Made with ✨ by Florimond Manca
   </p>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,11 +15,6 @@
     "lib": [
       "es2017",
       "dom"
-    ],
-    "paths": {
-      "moment": [
-        "../node_modules/moment/min/moment.min.js"
-      ]
-    }
+    ]
   }
 }


### PR DESCRIPTION
# Description

- Use the built-in `DatePipe` instead of Moment.js, for lighter bundle size.